### PR TITLE
Use correct route name after player creation

### DIFF
--- a/maturity-level-one/src/Controllers/PlayersController.cs
+++ b/maturity-level-one/src/Controllers/PlayersController.cs
@@ -17,6 +17,7 @@ namespace maturity_level_one.Controllers
     [ValidateModel]
     public class PlayersController : ControllerBase
     {
+        private const string GetPlayerRoute = "Players_GetPlayer";
         private readonly IWorldCupRepository _worldCupRepository;
 
         public PlayersController(IWorldCupRepository worldCupRepository)
@@ -41,26 +42,30 @@ namespace maturity_level_one.Controllers
         public async Task<IActionResult> VoteAsBestPlayer(int id)
         {
             var player = await _worldCupRepository.GetPlayerAsync(id);
-            if (player == null) return NotFound();
+            if (player == null)
+            {
+                return NotFound();
+            }
 
             // Voting is not implemented yet, but this kind of api method should return '202' or '200'
             // depending on how it is implemented.
 
             return Accepted();
-
         }
-
-
-        [HttpGet("{id}", Name = "Players_GetPlayer")]
+        
+        [HttpGet("{id}", Name = GetPlayerRoute)]
         [SwaggerResponse(200, "OK")]
         [SwaggerResponse(404, "Player not found")]
         [SwaggerResponse(500, "API is not available")]
         public async Task<IActionResult> GetPlayer(int id)
         {
             var player = await _worldCupRepository.GetPlayerAsync(id);
-            if (player == null) return NotFound();
-            var results = Mapper.Map<PlayerDto>(player);
+            if (player == null)
+            {
+                return NotFound();
+            }
 
+            var results = Mapper.Map<PlayerDto>(player);
             return Ok(results);
 
         }
@@ -71,7 +76,6 @@ namespace maturity_level_one.Controllers
         public async Task<IActionResult> Create(NewPlayerDto player)
         {
             var team = await _worldCupRepository.GetTeamAsync(player.TeamId, includePlayers: false);
-
             if (team == null)
             {
                 return BadRequest($"The Team with Id {player.TeamId} does not exist.");
@@ -88,7 +92,7 @@ namespace maturity_level_one.Controllers
             await _worldCupRepository.CreatePlayerAsync(playerEntity);
             var result = Mapper.Map<PlayerDto>(playerEntity);
 
-            return CreatedAtRoute("get-player-byid", new { id = result.Id }, result);
+            return CreatedAtRoute(GetPlayerRoute, new { id = result.Id }, result);
         }
 
         [HttpPut("{id}", Name="Players_UpdateFull")]
@@ -102,6 +106,7 @@ namespace maturity_level_one.Controllers
             {
                 return NotFound();
             }
+
             var playerToBeUpdated = Mapper.Map<Player>(player);
             playerToBeUpdated.Id = id;
 
@@ -140,13 +145,14 @@ namespace maturity_level_one.Controllers
             {
                 return NotFound();
             }
+
             // DB to DTO
             var playerToBeUpdated = Mapper.Map<PlayerDto>(playerDb);
+
             //Apply the patch to the DTO. 
             player.ApplyTo(playerToBeUpdated);
             Mapper.Map(playerToBeUpdated, playerDb);
             await _worldCupRepository.UpdatePlayerAsync(playerDb);
-
 
             var results = Mapper.Map<PlayerDto>(playerDb);
             return Ok(results);


### PR DESCRIPTION
Creating new players is broken at the moment because of creating a pointer to the GET url by using old naming convention.

This PR fixes this.