### PR TITLE
#93 Don't use TDto as a parameter to the repository

### DIFF
--- a/maturity-level-two/src/Controllers/v1/CustomizationController.cs
+++ b/maturity-level-two/src/Controllers/v1/CustomizationController.cs
@@ -139,8 +139,8 @@ namespace Codit.LevelTwo.Controllers.v1
         [SwaggerResponse((int)HttpStatusCode.InternalServerError, "API is not available")]
         public async Task<IActionResult> UpdateIncremental(int id, [FromBody] CustomizationDto customizationDto)
         {
-            var CustomizationObj = await _coditoRepository.GetCustomizationAsync(id);
-            if (CustomizationObj == null)
+            var customizationObj = await _coditoRepository.GetCustomizationAsync(id);
+            if (customizationObj == null)
             {
                 return NotFound(new ProblemDetailsError(StatusCodes.Status404NotFound));
             }
@@ -148,7 +148,7 @@ namespace Codit.LevelTwo.Controllers.v1
             var customizationUpdated = Mapper.Map<Customization>(customizationDto);
             customizationUpdated.Id = id;
 
-            await _coditoRepository.ApplyPatchAsync<Customization, CustomizationDto>(customizationUpdated, customizationDto);
+            await _coditoRepository.ApplyPatchAsync(customizationUpdated);
             return NoContent();
 
         }

--- a/maturity-level-two/src/Services/CoditoRepository.cs
+++ b/maturity-level-two/src/Services/CoditoRepository.cs
@@ -66,17 +66,20 @@ namespace Codit.LevelTwo.Services
             
         }
 
-        public async Task ApplyPatchAsync<TEntity, TDto>(TEntity entityToUpdate, TDto dto) where TEntity : class
+        public async Task ApplyPatchAsync<TEntity>(TEntity entityUpdated) where TEntity : class
         {
-            if (dto == null)
-                throw new ArgumentNullException($"{nameof(dto)}", $"{nameof(dto)} cannot be null.");
+            if (entityUpdated == null)
+                throw new ArgumentNullException($"{nameof(entityUpdated)}", $"{nameof(entityUpdated)} cannot be null.");
 
-            var properties = dto.GetFilledProperties();
-            _coditoContext.Attach(entityToUpdate);
+            var properties = entityUpdated.GetFilledProperties();
+            _coditoContext.Attach(entityUpdated);
 
             foreach (var property in properties)
             {
-                _coditoContext.Entry(entityToUpdate).Property(property).IsModified = true;
+                if (property != "Id")
+                {
+                    _coditoContext.Entry(entityUpdated).Property(property).IsModified = true;
+                }       
             }
 
             await _coditoContext.SaveChangesAsync();
@@ -99,7 +102,5 @@ namespace Codit.LevelTwo.Services
 
             await _coditoContext.SaveChangesAsync();
         }
-
-        
     }
 }

--- a/maturity-level-two/src/Services/ICoditoRepository.cs
+++ b/maturity-level-two/src/Services/ICoditoRepository.cs
@@ -20,7 +20,8 @@ namespace Codit.LevelTwo.Services
         Task<Customization> GetCustomizationAsync(int id);
 
         Task CreateCustomizationAsync(Customization customization);
-        Task ApplyPatchAsync<TEntity, TDto>(TEntity entityToUpdate, TDto dto) where TEntity : class;
+        //Task ApplyPatchAsync<TEntity, TDto>(TEntity entityToUpdate, TDto dto) where TEntity : class;
+        Task ApplyPatchAsync<TEntity>(TEntity entityUpdated) where TEntity : class;
 
         Task ApplyCustomizationSaleAsync(Customization customization);
 

--- a/maturity-level-two/tests/Codit.UnitTest/CoditoRepositoryFake.cs
+++ b/maturity-level-two/tests/Codit.UnitTest/CoditoRepositoryFake.cs
@@ -73,7 +73,7 @@ namespace Codit.UnitTest
             throw new NotImplementedException();
         }
 
-        public Task ApplyPatchAsync<TEntity, TDto>(TEntity entityToUpdate, TDto dto) where TEntity : class
+        public Task ApplyPatchAsync<TEntity>(TEntity entityUpdated) where TEntity : class
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
[issue 93](https://github.com/CoditEU/practical-api-guidelines/issues/93)

TDto is exposed to the API, so we don't pass this as parameter to the repository.  Instead, pass in the TEntity in where the properties are already modified.