### PR TITLE
#99 use XUnit fixture for automapper initialization

### DIFF
--- a/maturity-level-two/tests/Codit.UnitTest/AutoMapperTestFixture.cs
+++ b/maturity-level-two/tests/Codit.UnitTest/AutoMapperTestFixture.cs
@@ -1,0 +1,19 @@
+﻿using Codit.LevelTwo;
+using Xunit;
+
+namespace Codit.UnitTest
+{
+    public class AutoMapperTestFixture
+    {
+        public AutoMapperTestFixture()
+        {
+            AutoMapperConfig.Initialize();
+        }        
+    }
+
+    [CollectionDefinition("AutoMapper")]
+    public class AutoMapperCollection : ICollectionFixture<AutoMapperTestFixture>
+    {
+    }
+
+}

--- a/maturity-level-two/tests/Codit.UnitTest/Controllers/CustomizationControllertest.cs
+++ b/maturity-level-two/tests/Codit.UnitTest/Controllers/CustomizationControllertest.cs
@@ -15,7 +15,6 @@ namespace Codit.UnitTest.Controllers
     [Collection("AutoMapper")]
     public class CustomizationControllerTest
     {
-        AutoMapperTestFixture autoMapperTextFixture;
 
         private readonly CustomizationController _controller;
 

--- a/maturity-level-two/tests/Codit.UnitTest/Controllers/CustomizationControllertest.cs
+++ b/maturity-level-two/tests/Codit.UnitTest/Controllers/CustomizationControllertest.cs
@@ -12,15 +12,16 @@ using Codit.LevelTwo;
 
 namespace Codit.UnitTest.Controllers
 {
+    [Collection("AutoMapper")]
     public class CustomizationControllerTest
     {
+        AutoMapperTestFixture autoMapperTextFixture;
 
         private readonly CustomizationController _controller;
 
         public CustomizationControllerTest()
         {
             _controller = new CustomizationController(new CoditoRepositoryFake());
-            AutoMapperConfig.Initialize();
         }
 
         [Fact]

--- a/maturity-level-two/tests/Codit.UnitTest/Controllers/carControllerTest.cs
+++ b/maturity-level-two/tests/Codit.UnitTest/Controllers/carControllerTest.cs
@@ -13,14 +13,16 @@ using Codit.UnitTest;
 
 namespace Codit.UnitTest.Controllers
 {
+    [Collection("AutoMapper")]
     public class CarControllerTest
     {
+        AutoMapperTestFixture autoMapperTextFixture;
+
         private readonly CarController _controller;
 
         public CarControllerTest()
         {
             _controller = new CarController(new CoditoRepositoryFake());
-            AutoMapperConfig.Initialize();
         }
 
         [Fact]

--- a/maturity-level-two/tests/Codit.UnitTest/Controllers/carControllerTest.cs
+++ b/maturity-level-two/tests/Codit.UnitTest/Controllers/carControllerTest.cs
@@ -16,7 +16,6 @@ namespace Codit.UnitTest.Controllers
     [Collection("AutoMapper")]
     public class CarControllerTest
     {
-        AutoMapperTestFixture autoMapperTextFixture;
 
         private readonly CarController _controller;
 

--- a/maturity-level-two/tests/Codit.UnitTest/Mappings/AutomapperTest.cs
+++ b/maturity-level-two/tests/Codit.UnitTest/Mappings/AutomapperTest.cs
@@ -7,12 +7,10 @@ using FluentAssertions;
 
 namespace Codit.UnitTest.Mappings
 {
+    [Collection("AutoMapper")]
     public class AutomapperTest
     {
-        public AutomapperTest()
-        {
-            AutoMapperConfig.Initialize();
-        }
+        AutoMapperTestFixture autoMapperTextFixture;
 
         [Fact]
         public void Map_CustomizationToDto_Test()

--- a/maturity-level-two/tests/Codit.UnitTest/Mappings/AutomapperTest.cs
+++ b/maturity-level-two/tests/Codit.UnitTest/Mappings/AutomapperTest.cs
@@ -10,7 +10,6 @@ namespace Codit.UnitTest.Mappings
     [Collection("AutoMapper")]
     public class AutomapperTest
     {
-        AutoMapperTestFixture autoMapperTextFixture;
 
         [Fact]
         public void Map_CustomizationToDto_Test()


### PR DESCRIPTION
Fixing issue #99 : Created a XUnit collection fixture for the unit test, so that automapper is initialized only once.